### PR TITLE
LFLT-361 Sitemap should be exposed to LCFA via Bridge

### DIFF
--- a/core/src/main/java/hu/psprog/leaflet/lcfa/core/facade/CommonPageDataFacade.java
+++ b/core/src/main/java/hu/psprog/leaflet/lcfa/core/facade/CommonPageDataFacade.java
@@ -1,5 +1,6 @@
 package hu.psprog.leaflet.lcfa.core.facade;
 
+import hu.psprog.leaflet.api.rest.response.sitemap.Sitemap;
 import hu.psprog.leaflet.lcfa.core.domain.common.CommonPageData;
 
 /**
@@ -16,4 +17,12 @@ public interface CommonPageDataFacade {
      * @return populated {@link CommonPageData}
      */
     CommonPageData getCommonPageData();
+
+    /**
+     * Retrieves sitemap.
+     * In case of failure, an empty instance is returned.
+     *
+     * @return populated sitemap as {@link Sitemap}
+     */
+    Sitemap getSitemap();
 }

--- a/core/src/main/java/hu/psprog/leaflet/lcfa/core/facade/adapter/ContentRequestAdapterIdentifier.java
+++ b/core/src/main/java/hu/psprog/leaflet/lcfa/core/facade/adapter/ContentRequestAdapterIdentifier.java
@@ -24,6 +24,7 @@ public enum ContentRequestAdapterIdentifier {
     PROFILE_PASSWORD_CHANGE,
     PROFILE_UPDATE,
     SIGN_UP,
+    SITEMAP,
     STATIC_PAGE,
     TAG_FILTER
 }

--- a/core/src/main/java/hu/psprog/leaflet/lcfa/core/facade/adapter/impl/SitemapContentRequestAdapter.java
+++ b/core/src/main/java/hu/psprog/leaflet/lcfa/core/facade/adapter/impl/SitemapContentRequestAdapter.java
@@ -1,0 +1,50 @@
+package hu.psprog.leaflet.lcfa.core.facade.adapter.impl;
+
+import hu.psprog.leaflet.api.rest.response.sitemap.Sitemap;
+import hu.psprog.leaflet.bridge.client.exception.CommunicationFailureException;
+import hu.psprog.leaflet.bridge.client.exception.DefaultNonSuccessfulResponseException;
+import hu.psprog.leaflet.bridge.service.SitemapBridgeService;
+import hu.psprog.leaflet.lcfa.core.facade.adapter.ContentRequestAdapter;
+import hu.psprog.leaflet.lcfa.core.facade.adapter.ContentRequestAdapterIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * {@link ContentRequestAdapter} implementation to retrieve sitemap.
+ *
+ * @author Peter Smith
+ */
+@Component
+public class SitemapContentRequestAdapter implements ContentRequestAdapter<Sitemap, Void> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SitemapContentRequestAdapter.class);
+
+    private SitemapBridgeService sitemapBridgeService;
+
+    @Autowired
+    public SitemapContentRequestAdapter(SitemapBridgeService sitemapBridgeService) {
+        this.sitemapBridgeService = sitemapBridgeService;
+    }
+
+    @Override
+    public Optional<Sitemap> getContent(Void contentRequestParameter) {
+
+        Sitemap sitemap = null;
+        try {
+            sitemap = sitemapBridgeService.getSitemap();
+        } catch (DefaultNonSuccessfulResponseException | CommunicationFailureException e) {
+            LOGGER.error("Failed to retrieve sitemap.", e);
+        }
+
+        return Optional.ofNullable(sitemap);
+    }
+
+    @Override
+    public ContentRequestAdapterIdentifier getIdentifier() {
+        return ContentRequestAdapterIdentifier.SITEMAP;
+    }
+}

--- a/core/src/main/java/hu/psprog/leaflet/lcfa/core/facade/impl/CommonPageDataFacadeImpl.java
+++ b/core/src/main/java/hu/psprog/leaflet/lcfa/core/facade/impl/CommonPageDataFacadeImpl.java
@@ -2,6 +2,7 @@ package hu.psprog.leaflet.lcfa.core.facade.impl;
 
 import hu.psprog.leaflet.api.rest.response.common.WrapperBodyDataModel;
 import hu.psprog.leaflet.api.rest.response.entry.EntryListDataModel;
+import hu.psprog.leaflet.api.rest.response.sitemap.Sitemap;
 import hu.psprog.leaflet.lcfa.core.config.PageConfigModel;
 import hu.psprog.leaflet.lcfa.core.converter.CommonPageDataConverter;
 import hu.psprog.leaflet.lcfa.core.domain.common.CommonPageData;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service;
 import java.util.function.Supplier;
 
 import static hu.psprog.leaflet.lcfa.core.facade.adapter.ContentRequestAdapterIdentifier.COMMON_PAGE_DATA;
+import static hu.psprog.leaflet.lcfa.core.facade.adapter.ContentRequestAdapterIdentifier.SITEMAP;
 
 /**
  * Implementation of {@link CommonPageDataFacade}.
@@ -34,6 +36,7 @@ public class CommonPageDataFacadeImpl implements CommonPageDataFacade {
     private static final int PAGE_NUMBER = 1;
     private static final OrderBy.Entry ORDER_BY = OrderBy.Entry.CREATED;
     private static final OrderDirection ORDER_DIRECTION = OrderDirection.DESC;
+    private static final Sitemap EMPTY_SITEMAP = Sitemap.getBuilder().build();
 
     private ContentRequestAdapterRegistry contentRequestAdapterRegistry;
     private CommonPageDataCache commonPageDataCache;
@@ -54,6 +57,13 @@ public class CommonPageDataFacadeImpl implements CommonPageDataFacade {
     public CommonPageData getCommonPageData() {
         return commonPageDataCache.getCached()
                 .orElseGet(requestCommonPageData());
+    }
+
+    @Override
+    public Sitemap getSitemap() {
+        return contentRequestAdapterRegistry.<Sitemap, Void>getContentRequestAdapter(SITEMAP)
+                .getContent(null)
+                .orElse(EMPTY_SITEMAP);
     }
 
     private PaginatedContentRequest initLatestEntriesRequest(int numberOfLatestEntries) {

--- a/core/src/test/java/hu/psprog/leaflet/lcfa/core/facade/adapter/ContentRequestAdapterRegistryTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lcfa/core/facade/adapter/ContentRequestAdapterRegistryTest.java
@@ -97,7 +97,7 @@ public class ContentRequestAdapterRegistryTest {
         Set<ContentRequestAdapterIdentifier> contentRequestAdapterIdentifierSetMock = Mockito.mock(Set.class);
 
         given(contentRequestAdapterMapMock.keySet()).willReturn(contentRequestAdapterIdentifierSetMock);
-        given(contentRequestAdapterIdentifierSetMock.size()).willReturn(18);
+        given(contentRequestAdapterIdentifierSetMock.size()).willReturn(19);
 
         Field contentRequestAdapterMapField = ReflectionUtils.findField(ContentRequestAdapterRegistry.class, "contentRequestAdapterMap");
         contentRequestAdapterMapField.setAccessible(true);

--- a/core/src/test/java/hu/psprog/leaflet/lcfa/core/facade/adapter/impl/SitemapContentRequestAdapterTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lcfa/core/facade/adapter/impl/SitemapContentRequestAdapterTest.java
@@ -1,0 +1,77 @@
+package hu.psprog.leaflet.lcfa.core.facade.adapter.impl;
+
+import hu.psprog.leaflet.api.rest.response.sitemap.Sitemap;
+import hu.psprog.leaflet.bridge.client.exception.CommunicationFailureException;
+import hu.psprog.leaflet.bridge.service.SitemapBridgeService;
+import hu.psprog.leaflet.lcfa.core.facade.adapter.ContentRequestAdapterIdentifier;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+
+/**
+ * Unit tests for {@link SitemapContentRequestAdapter}.
+ *
+ * @author Peter Smith
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SitemapContentRequestAdapterTest {
+
+    private static final Sitemap SITEMAP = Sitemap.getBuilder()
+            .withLocation("/location/test")
+            .build();
+
+    @Mock
+    private SitemapBridgeService sitemapBridgeService;
+
+    @InjectMocks
+    private SitemapContentRequestAdapter adapter;
+
+    @Test
+    public void shouldGetContentReturnWithSuccess() throws CommunicationFailureException {
+
+        // given
+        given(sitemapBridgeService.getSitemap()).willReturn(SITEMAP);
+
+        // when
+        Optional<Sitemap> result = adapter.getContent(null);
+
+        // then
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get(), equalTo(SITEMAP));
+    }
+
+    @Test
+    public void shouldGetContentReturnWithEmptyResponseInCaseOfBridgeFailure() throws CommunicationFailureException {
+
+        // given
+        doThrow(CommunicationFailureException.class).when(sitemapBridgeService).getSitemap();
+
+        // when
+        Optional<Sitemap> result = adapter.getContent(null);
+
+        // then
+        assertThat(result.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldGetIdentifierReturnProperValue() {
+
+        // when
+        ContentRequestAdapterIdentifier result = adapter.getIdentifier();
+
+        // then
+        assertThat(result, notNullValue());
+        assertThat(result, equalTo(ContentRequestAdapterIdentifier.SITEMAP));
+    }
+}

--- a/core/src/test/java/hu/psprog/leaflet/lcfa/core/facade/impl/CommonPageDataFacadeImplTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lcfa/core/facade/impl/CommonPageDataFacadeImplTest.java
@@ -3,6 +3,7 @@ package hu.psprog.leaflet.lcfa.core.facade.impl;
 import hu.psprog.leaflet.api.rest.response.common.WrapperBodyDataModel;
 import hu.psprog.leaflet.api.rest.response.entry.EntryDataModel;
 import hu.psprog.leaflet.api.rest.response.entry.EntryListDataModel;
+import hu.psprog.leaflet.api.rest.response.sitemap.Sitemap;
 import hu.psprog.leaflet.lcfa.core.config.CommonPageDataCacheConfigModel;
 import hu.psprog.leaflet.lcfa.core.config.PageConfigModel;
 import hu.psprog.leaflet.lcfa.core.converter.CommonPageDataConverter;
@@ -30,6 +31,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -61,6 +63,10 @@ public class CommonPageDataFacadeImplTest {
     private static final WrapperBodyDataModel<EntryListDataModel> WRAPPED_ENTRY_LIST_DATA_MODEL = WrapperBodyDataModel.getBuilder()
             .withBody(EntryListDataModel.getBuilder().withItem(EntryDataModel.getBuilder().withId(3L).build()).build())
             .build();
+    private static final Sitemap SITEMAP = Sitemap.getBuilder()
+            .withLocation("/location/test")
+            .build();
+    private static final Sitemap EMPTY_SITEMAP = Sitemap.getBuilder().build();
 
     static {
         COMMON_PAGE_DATA_CACHE_CONFIG_MODEL.setLatestEntriesCount(LATEST_ENTRIES_COUNT);
@@ -78,6 +84,9 @@ public class CommonPageDataFacadeImplTest {
 
     @Mock
     private ContentRequestAdapter<WrapperBodyDataModel<EntryListDataModel>, PaginatedContentRequest> commonPageDataContentRequestAdapter;
+
+    @Mock
+    private ContentRequestAdapter<Sitemap, Void> sitemapContentRequestAdapter;
 
     private CommonPageDataFacadeImpl commonPageDataFacade;
 
@@ -136,5 +145,37 @@ public class CommonPageDataFacadeImplTest {
 
         // then
         // exception expected
+    }
+
+    @Test
+    public void shouldGetSitemapReturnWithSuccess() {
+
+        // given
+        given(contentRequestAdapterRegistry.<Sitemap, Void>getContentRequestAdapter(ContentRequestAdapterIdentifier.SITEMAP))
+                .willReturn(sitemapContentRequestAdapter);
+        given(sitemapContentRequestAdapter.getContent(nullable(Void.class))).willReturn(Optional.of(SITEMAP));
+
+        // when
+        Sitemap result = commonPageDataFacade.getSitemap();
+
+        // then
+        assertThat(result, notNullValue());
+        assertThat(result, equalTo(SITEMAP));
+    }
+
+    @Test
+    public void shouldGetSitemapReturnEmptySitemapForMissingData() {
+
+        // given
+        given(contentRequestAdapterRegistry.<Sitemap, Void>getContentRequestAdapter(ContentRequestAdapterIdentifier.SITEMAP))
+                .willReturn(sitemapContentRequestAdapter);
+        given(sitemapContentRequestAdapter.getContent(nullable(Void.class))).willReturn(Optional.empty());
+
+        // when
+        Sitemap result = commonPageDataFacade.getSitemap();
+
+        // then
+        assertThat(result, notNullValue());
+        assertThat(result, equalTo(EMPTY_SITEMAP));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
         <java.version>11</java.version>
 
         <!-- leaflet internal dependency versions -->
-        <leaflet.rest-api.version>1.6.3</leaflet.rest-api.version>
-        <leaflet.rcp.version>1.5.2</leaflet.rcp.version>
+        <leaflet.rest-api.version>1.6.4</leaflet.rest-api.version>
+        <leaflet.rcp.version>1.5.3</leaflet.rcp.version>
         <leaflet.bridge.version>3.2.2</leaflet.bridge.version>
         <leaflet.tlp-appender.version>1.1.0</leaflet.tlp-appender.version>
         <leaflet.translation-adapter.version>2.1.0</leaflet.translation-adapter.version>
@@ -249,6 +249,11 @@
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${hibernate-validator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -80,6 +80,10 @@
             <groupId>pl.pragmatists</groupId>
             <artifactId>JUnitParams</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/web/src/main/java/hu/psprog/leaflet/lcfa/web/controller/SitemapController.java
+++ b/web/src/main/java/hu/psprog/leaflet/lcfa/web/controller/SitemapController.java
@@ -1,0 +1,41 @@
+package hu.psprog.leaflet.lcfa.web.controller;
+
+import hu.psprog.leaflet.api.rest.response.sitemap.Sitemap;
+import hu.psprog.leaflet.lcfa.core.facade.CommonPageDataFacade;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.MediaType.ALL_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+
+/**
+ * Controller implementation that renders sitemap as XML document.
+ * Format is compatible with Google Search Console requirements.
+ *
+ * @author Peter Smith
+ */
+@RestController
+public class SitemapController {
+
+    private static final String PATH_SITEMAP = "/sitemap.xml";
+
+    private CommonPageDataFacade commonPageDataFacade;
+
+    @Autowired
+    public SitemapController(CommonPageDataFacade commonPageDataFacade) {
+        this.commonPageDataFacade = commonPageDataFacade;
+    }
+
+    /**
+     * GET /sitemap.xml
+     * Renders sitemap.
+     *
+     * @return populated sitemap as XML document
+     */
+    @GetMapping(path = PATH_SITEMAP, produces = APPLICATION_XML_VALUE, consumes = ALL_VALUE)
+    public ResponseEntity<Sitemap> renderSitemap() {
+        return ResponseEntity.ok(commonPageDataFacade.getSitemap());
+    }
+}

--- a/web/src/test/java/hu/psprog/leaflet/lcfa/web/controller/SitemapControllerTest.java
+++ b/web/src/test/java/hu/psprog/leaflet/lcfa/web/controller/SitemapControllerTest.java
@@ -1,0 +1,50 @@
+package hu.psprog.leaflet.lcfa.web.controller;
+
+import hu.psprog.leaflet.api.rest.response.sitemap.Sitemap;
+import hu.psprog.leaflet.lcfa.core.facade.CommonPageDataFacade;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Unit tests for {@link SitemapController}.
+ *
+ * @author Peter Smith
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SitemapControllerTest {
+
+    private static final Sitemap SITEMAP = Sitemap.getBuilder()
+            .withLocation("/location/test")
+            .build();
+
+    @Mock
+    private CommonPageDataFacade commonPageDataFacade;
+
+    @InjectMocks
+    private SitemapController sitemapController;
+
+    @Test
+    public void shouldRenderSitemap() {
+
+        // given
+        given(commonPageDataFacade.getSitemap()).willReturn(SITEMAP);
+
+        // when
+        ResponseEntity<Sitemap> result = sitemapController.renderSitemap();
+
+        // then
+        assertThat(result, notNullValue());
+        assertThat(result.getStatusCode(), equalTo(HttpStatus.OK));
+        assertThat(result.getBody(), equalTo(SITEMAP));
+    }
+}


### PR DESCRIPTION
 - Added ContentRequestAdapter and facade entry point for sitemap retrieval
 - Added controller for rendering sitemap
 - Added Jackson XML data format extension for serializing sitemap as XML
 - Updated REST API version to v1.6.4
 - Updated RCP version to v1.5.3
 - Added tests