### PR TITLE
LFLT-362 Images in articles are sized to 100% width

### DIFF
--- a/web/src/main/resources/webapp/resources/css/site.css
+++ b/web/src/main/resources/webapp/resources/css/site.css
@@ -584,7 +584,9 @@ pre.prettyprint {
 }
 
 .entryPrologue img {
-	width: 100%;
+	max-width: 95%;
+	display: block;
+	margin: auto;
 }
 
 .entryPrologue p a {


### PR DESCRIPTION
 - Changed width of article images to max-width of 95%
 - Set images to be centered