### PR TITLE
LFLT-363 Add publish date for articles

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-content-front-application</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.0.2-dev</version>
+        <version>1.0.3-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/hu/psprog/leaflet/lcfa/core/converter/ArticleConverter.java
+++ b/core/src/main/java/hu/psprog/leaflet/lcfa/core/converter/ArticleConverter.java
@@ -10,6 +10,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
 /**
  * Converts {@link ExtendedEntryDataModel} wrapped as {@link WrapperBodyDataModel} to {@link Article}.
  *
@@ -38,7 +41,7 @@ public class ArticleConverter implements Converter<WrapperBodyDataModel<Extended
                 .id(source.getBody().getId())
                 .author(createAuthorSummary(source.getBody()))
                 .content(source.getBody().getRawContent())
-                .creationDate(dateFormatterUtility.formatGeneral(source.getBody().getCreated()))
+                .creationDate(dateFormatterUtility.formatGeneral(extractCreationDate(source.getBody())))
                 .link(source.getBody().getLink())
                 .title(source.getBody().getTitle())
                 .tags(tagSummaryListConverter.convert(source.getBody().getTags()))
@@ -49,5 +52,10 @@ public class ArticleConverter implements Converter<WrapperBodyDataModel<Extended
 
     private AuthorSummary createAuthorSummary(EntryDataModel entryDataModel) {
         return new AuthorSummary(entryDataModel.getUser().getUsername());
+    }
+
+    private ZonedDateTime extractCreationDate(EntryDataModel entryDataModel) {
+        return Optional.ofNullable(entryDataModel.getPublished())
+                .orElse(entryDataModel.getCreated());
     }
 }

--- a/core/src/main/java/hu/psprog/leaflet/lcfa/core/converter/EntrySummaryListConverter.java
+++ b/core/src/main/java/hu/psprog/leaflet/lcfa/core/converter/EntrySummaryListConverter.java
@@ -9,7 +9,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
+import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -39,12 +41,17 @@ public class EntrySummaryListConverter implements Converter<EntryListDataModel, 
                 .link(entryDataModel.getLink())
                 .title(entryDataModel.getTitle())
                 .author(createAuthorSummary(entryDataModel))
-                .creationDate(dateFormatterUtility.formatGeneral(entryDataModel.getCreated()))
+                .creationDate(dateFormatterUtility.formatGeneral(extractCreationDate(entryDataModel)))
                 .prologue(entryDataModel.getPrologue())
                 .build();
     }
 
     private AuthorSummary createAuthorSummary(EntryDataModel entryDataModel) {
         return new AuthorSummary(entryDataModel.getUser().getUsername());
+    }
+
+    private ZonedDateTime extractCreationDate(EntryDataModel entryDataModel) {
+        return Optional.ofNullable(entryDataModel.getPublished())
+                .orElse(entryDataModel.getCreated());
     }
 }

--- a/core/src/main/java/hu/psprog/leaflet/lcfa/core/domain/content/request/OrderBy.java
+++ b/core/src/main/java/hu/psprog/leaflet/lcfa/core/domain/content/request/OrderBy.java
@@ -13,7 +13,8 @@ public class OrderBy {
     public enum Entry {
         ID,
         TITLE,
-        CREATED
+        CREATED,
+        PUBLISHED
     }
 
     /**

--- a/core/src/test/java/hu/psprog/leaflet/lcfa/core/converter/ArticleConverterTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lcfa/core/converter/ArticleConverterTest.java
@@ -12,6 +12,7 @@ import hu.psprog.leaflet.lcfa.core.domain.content.AuthorSummary;
 import hu.psprog.leaflet.lcfa.core.domain.content.CategorySummary;
 import hu.psprog.leaflet.lcfa.core.domain.content.TagSummary;
 import hu.psprog.leaflet.lcfa.core.formatter.DateFormatterUtility;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -39,12 +40,13 @@ public class ArticleConverterTest {
     private static final String USERNAME = "username";
     private static final String RAW_CONTENT = "raw-content";
     private static final ZonedDateTime CREATED = ZonedDateTime.now();
+    private static final ZonedDateTime PUBLISHED = ZonedDateTime.now().plusDays(1);
     private static final String LINK = "link";
     private static final String TITLE = "title";
     private static final List<TagDataModel> TAG_DATA_MODEL_LIST = Collections.singletonList(TagDataModel.getBuilder().withId(2L).build());
     private static final List<FileDataModel> FILE_DATA_MODEL_LIST = Collections.singletonList(FileDataModel.getBuilder().withReference("file-ref").build());
     private static final CategoryDataModel CATEGORY_DATA_MODEL = CategoryDataModel.getBuilder().withID(3L).build();
-    private static final ExtendedEntryDataModel EXTENDED_ENTRY_DATA_MODEL = ExtendedEntryDataModel.getExtendedBuilder()
+    private static final ExtendedEntryDataModel EXTENDED_ENTRY_DATA_MODEL_WITHOUT_PUBLISHED_DATE = ExtendedEntryDataModel.getExtendedBuilder()
             .withId(ENTRY_ID)
             .withUser(UserDataModel.getBuilder()
                     .withUsername(USERNAME)
@@ -57,18 +59,47 @@ public class ArticleConverterTest {
             .withAttachments(FILE_DATA_MODEL_LIST)
             .withCategory(CATEGORY_DATA_MODEL)
             .build();
-    private static final WrapperBodyDataModel<ExtendedEntryDataModel> SOURCE_OBJECT = WrapperBodyDataModel.<ExtendedEntryDataModel>getBuilder()
-            .withBody(EXTENDED_ENTRY_DATA_MODEL)
+    private static final ExtendedEntryDataModel EXTENDED_ENTRY_DATA_MODEL_WITH_PUBLISHED_DATE = ExtendedEntryDataModel.getExtendedBuilder()
+            .withId(ENTRY_ID)
+            .withUser(UserDataModel.getBuilder()
+                    .withUsername(USERNAME)
+                    .build())
+            .withRawContent(RAW_CONTENT)
+            .withCreated(CREATED)
+            .withPublished(PUBLISHED)
+            .withLink(LINK)
+            .withTitle(TITLE)
+            .withTags(TAG_DATA_MODEL_LIST)
+            .withAttachments(FILE_DATA_MODEL_LIST)
+            .withCategory(CATEGORY_DATA_MODEL)
+            .build();
+    private static final WrapperBodyDataModel<ExtendedEntryDataModel> SOURCE_OBJECT_WITHOUT_PUBLISHED_DATE = WrapperBodyDataModel.<ExtendedEntryDataModel>getBuilder()
+            .withBody(EXTENDED_ENTRY_DATA_MODEL_WITHOUT_PUBLISHED_DATE)
+            .build();
+    private static final WrapperBodyDataModel<ExtendedEntryDataModel> SOURCE_OBJECT_WITH_PUBLISHED_DATE = WrapperBodyDataModel.<ExtendedEntryDataModel>getBuilder()
+            .withBody(EXTENDED_ENTRY_DATA_MODEL_WITH_PUBLISHED_DATE)
             .build();
     private static final List<TagSummary> TAG_SUMMARY_LIST = Collections.singletonList(TagSummary.builder().id(2L).build());
     private static final CategorySummary CATEGORY_SUMMARY = CategorySummary.builder().id(4L).build();
     private static final List<AttachmentSummary> ATTACHMENT_SUMMARY_LIST = Collections.singletonList(AttachmentSummary.builder().link("attachment-link").build());
     private static final String FORMATTED_CREATION_DATE = "creation-date";
-    private static final Article EXPECTED_CONVERTED_OBJECT = Article.builder()
+    private static final String FORMATTED_PUBLISHED_DATE = "published-date";
+    private static final Article EXPECTED_CONVERTED_OBJECT_WITHOUT_PUBLISHED_DATE = Article.builder()
             .id(ENTRY_ID)
             .author(new AuthorSummary(USERNAME))
             .content(RAW_CONTENT)
             .creationDate(FORMATTED_CREATION_DATE)
+            .link(LINK)
+            .title(TITLE)
+            .tags(TAG_SUMMARY_LIST)
+            .category(CATEGORY_SUMMARY)
+            .attachments(ATTACHMENT_SUMMARY_LIST)
+            .build();
+    private static final Article EXPECTED_CONVERTED_OBJECT_WITH_PUBLISHED_DATE = Article.builder()
+            .id(ENTRY_ID)
+            .author(new AuthorSummary(USERNAME))
+            .content(RAW_CONTENT)
+            .creationDate(FORMATTED_PUBLISHED_DATE)
             .link(LINK)
             .title(TITLE)
             .tags(TAG_SUMMARY_LIST)
@@ -91,20 +122,40 @@ public class ArticleConverterTest {
     @InjectMocks
     private ArticleConverter converter;
 
-    @Test
-    public void shouldConvert() {
+    @Before
+    public void setup() {
 
         // given
-        given(dateFormatterUtility.formatGeneral(CREATED)).willReturn(FORMATTED_CREATION_DATE);
         given(tagSummaryListConverter.convert(TAG_DATA_MODEL_LIST)).willReturn(TAG_SUMMARY_LIST);
         given(attachmentSummaryListConverter.convert(FILE_DATA_MODEL_LIST)).willReturn(ATTACHMENT_SUMMARY_LIST);
         given(categorySummaryConverter.convert(CATEGORY_DATA_MODEL)).willReturn(CATEGORY_SUMMARY);
+    }
+
+    @Test
+    public void shouldConvertWithoutPublishedDate() {
+
+        // given
+        given(dateFormatterUtility.formatGeneral(CREATED)).willReturn(FORMATTED_CREATION_DATE);
 
         // when
-        Article result = converter.convert(SOURCE_OBJECT);
+        Article result = converter.convert(SOURCE_OBJECT_WITHOUT_PUBLISHED_DATE);
 
         // then
         assertThat(result, notNullValue());
-        assertThat(result, equalTo(EXPECTED_CONVERTED_OBJECT));
+        assertThat(result, equalTo(EXPECTED_CONVERTED_OBJECT_WITHOUT_PUBLISHED_DATE));
+    }
+
+    @Test
+    public void shouldConvertWithPublishedDate() {
+
+        // given
+        given(dateFormatterUtility.formatGeneral(PUBLISHED)).willReturn(FORMATTED_PUBLISHED_DATE);
+
+        // when
+        Article result = converter.convert(SOURCE_OBJECT_WITH_PUBLISHED_DATE);
+
+        // then
+        assertThat(result, notNullValue());
+        assertThat(result, equalTo(EXPECTED_CONVERTED_OBJECT_WITH_PUBLISHED_DATE));
     }
 }

--- a/core/src/test/java/hu/psprog/leaflet/lcfa/core/converter/EntrySummaryListConverterTest.java
+++ b/core/src/test/java/hu/psprog/leaflet/lcfa/core/converter/EntrySummaryListConverterTest.java
@@ -30,11 +30,13 @@ public class EntrySummaryListConverterTest {
 
     private static final String USERNAME = "username";
     private static final ZonedDateTime CREATED = ZonedDateTime.now();
+    private static final ZonedDateTime PUBLISHED = ZonedDateTime.now().plusDays(1);
     private static final String FORMATTED_CREATED_DATE = "formatted-created-date";
+    private static final String FORMATTED_PUBLISHED_DATE = "formatted-published-date";
     private static final String LINK = "link";
     private static final String TITLE = "title";
     private static final String PROLOGUE = "prologue";
-    private static final EntryDataModel ENTRY_DATA_MODEL = EntryDataModel.getBuilder()
+    private static final EntryDataModel ENTRY_DATA_MODEL_WITHOUT_PUBLISHED_DATE = EntryDataModel.getBuilder()
             .withLink(LINK)
             .withTitle(TITLE)
             .withUser(UserDataModel.getBuilder()
@@ -43,11 +45,28 @@ public class EntrySummaryListConverterTest {
             .withCreated(CREATED)
             .withPrologue(PROLOGUE)
             .build();
-    private static final EntrySummary ENTRY_SUMMARY = EntrySummary.builder()
+    private static final EntrySummary ENTRY_SUMMARY_WITHOUT_PUBLISHED_DATE = EntrySummary.builder()
             .link(LINK)
             .title(TITLE)
             .author(new AuthorSummary(USERNAME))
             .creationDate(FORMATTED_CREATED_DATE)
+            .prologue(PROLOGUE)
+            .build();
+    private static final EntryDataModel ENTRY_DATA_MODEL_WITH_PUBLISHED_DATE = EntryDataModel.getBuilder()
+            .withLink(LINK)
+            .withTitle(TITLE)
+            .withUser(UserDataModel.getBuilder()
+                    .withUsername(USERNAME)
+                    .build())
+            .withCreated(CREATED)
+            .withPublished(PUBLISHED)
+            .withPrologue(PROLOGUE)
+            .build();
+    private static final EntrySummary ENTRY_SUMMARY_WITH_PUBLISHED_DATE = EntrySummary.builder()
+            .link(LINK)
+            .title(TITLE)
+            .author(new AuthorSummary(USERNAME))
+            .creationDate(FORMATTED_PUBLISHED_DATE)
             .prologue(PROLOGUE)
             .build();
 
@@ -58,12 +77,12 @@ public class EntrySummaryListConverterTest {
     private EntrySummaryListConverter converter;
 
     @Test
-    public void shouldConvert() {
+    public void shouldConvertWithoutPublishedDate() {
 
         // given
         given(dateFormatterUtility.formatGeneral(CREATED)).willReturn(FORMATTED_CREATED_DATE);
         EntryListDataModel entryListDataModel = EntryListDataModel.getBuilder()
-                .withItem(ENTRY_DATA_MODEL)
+                .withItem(ENTRY_DATA_MODEL_WITHOUT_PUBLISHED_DATE)
                 .build();
 
         // when
@@ -71,6 +90,23 @@ public class EntrySummaryListConverterTest {
 
         // then
         assertThat(result, notNullValue());
-        assertThat(result, hasItem(ENTRY_SUMMARY));
+        assertThat(result, hasItem(ENTRY_SUMMARY_WITHOUT_PUBLISHED_DATE));
+    }
+
+    @Test
+    public void shouldConvertWithPublishedDate() {
+
+        // given
+        given(dateFormatterUtility.formatGeneral(PUBLISHED)).willReturn(FORMATTED_PUBLISHED_DATE);
+        EntryListDataModel entryListDataModel = EntryListDataModel.getBuilder()
+                .withItem(ENTRY_DATA_MODEL_WITH_PUBLISHED_DATE)
+                .build();
+
+        // when
+        List<EntrySummary> result = converter.convert(entryListDataModel);
+
+        // then
+        assertThat(result, notNullValue());
+        assertThat(result, hasItem(ENTRY_SUMMARY_WITH_PUBLISHED_DATE));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>hu.psprog.leaflet</groupId>
     <artifactId>leaflet-content-front-application</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.2-dev</version>
+    <version>1.0.3-dev</version>
 
     <modules>
         <module>web</module>
@@ -30,9 +30,9 @@
         <java.version>11</java.version>
 
         <!-- leaflet internal dependency versions -->
-        <leaflet.rest-api.version>1.6.5</leaflet.rest-api.version>
+        <leaflet.rest-api.version>1.6.6</leaflet.rest-api.version>
         <leaflet.rcp.version>1.5.3</leaflet.rcp.version>
-        <leaflet.bridge.version>3.2.2</leaflet.bridge.version>
+        <leaflet.bridge.version>3.2.3</leaflet.bridge.version>
         <leaflet.tlp-appender.version>1.1.0</leaflet.tlp-appender.version>
         <leaflet.translation-adapter.version>2.1.0</leaflet.translation-adapter.version>
         <leaflet.jwt-auth-support.version>1.0.1</leaflet.jwt-auth-support.version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-content-front-application</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.0.2-dev</version>
+        <version>1.0.3-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - Aligned related converters to handle published date
 - Added published field as an option of ordering
 - Updated REST API version to v1.6.6
 - Updated Bridge version to v3.2.3