### PR TITLE
LFLT-323 Missing spring.factories in translation adapter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <leaflet.rcp.version>1.5.3</leaflet.rcp.version>
         <leaflet.bridge.version>3.2.3</leaflet.bridge.version>
         <leaflet.tlp-appender.version>1.1.0</leaflet.tlp-appender.version>
-        <leaflet.translation-adapter.version>2.1.0</leaflet.translation-adapter.version>
+        <leaflet.translation-adapter.version>2.1.1</leaflet.translation-adapter.version>
         <leaflet.jwt-auth-support.version>1.0.1</leaflet.jwt-auth-support.version>
 
         <!-- Spring versions -->

--- a/web/src/main/java/hu/psprog/leaflet/lcfa/web/config/ApplicationContextConfig.java
+++ b/web/src/main/java/hu/psprog/leaflet/lcfa/web/config/ApplicationContextConfig.java
@@ -2,7 +2,6 @@ package hu.psprog.leaflet.lcfa.web.config;
 
 import org.springframework.boot.web.servlet.filter.OrderedRequestContextFilter;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.task.AsyncTaskExecutor;
@@ -15,7 +14,6 @@ import org.springframework.web.filter.RequestContextFilter;
  * @author Peter Smith
  */
 @Configuration
-@ComponentScan("hu.psprog.leaflet.translation.adapter") // TODO fix a4tms (no spring.factories)
 public class ApplicationContextConfig {
 
     @Bean


### PR DESCRIPTION
 - Updated translation adapter version to v2.1.1
 - Removed unnecessary component scan (fixed by new translation adapter version)