### PR TITLE
LFLT-655 Migrate Java applications to Spring Boot v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   jira: circleci/jira@2.2.0
-  gh: circleci/github-cli@2.7.0
+  gh: circleci/github-cli@2.7.2
 
 # Common parameters for CircleCI build config
 parameters:
@@ -24,6 +24,9 @@ parameters:
   version_file:
     type: string
     default: "version"
+  deploy_name:
+    type: string
+    default: "prod-deploy-lcfa"
 
 # Reusable commands
 commands:
@@ -93,6 +96,15 @@ jobs:
             fi
           name: Push Docker image
       - run:
+          name: Plan deployment
+          command: |
+            if [[ $CIRCLE_BRANCH == "deploy" ]]; then
+              circleci run release plan << pipeline.parameters.deploy_name >> \
+                --environment-name=production \
+                --component-name=<< pipeline.parameters.app_name >> \
+                --target-version="${PROJECT_VERSION}"
+            fi
+      - run:
           command: |
             mkdir -p << pipeline.parameters.workspace_dir >>
             cp ./<< pipeline.parameters.executable_source_dir >><< pipeline.parameters.executable_file >> << pipeline.parameters.workspace_dir >>/<< pipeline.parameters.executable_file >>
@@ -127,12 +139,17 @@ jobs:
           command: |
             set -e
             
+            circleci run release update << pipeline.parameters.deploy_name >> --status=running
+            
             echo "Requesting access token ..."
             token="$(domino-cli --cicd auth --generate-token)" || exit 1
             export DOMINO_CLI_PREAUTHORIZED_TOKEN=$token
             
             domino-cli --cicd import
             echo "Deployment definition successfully imported"
+            
+            domino-cli --cicd oauth-import << pipeline.parameters.app_name >>
+            echo "Deployment OAuth descriptor successfully imported"
             
             domino-cli --cicd deploy << pipeline.parameters.app_name >> ${PROJECT_VERSION}
             echo "Successfully deployed application << pipeline.parameters.app_name >> v${PROJECT_VERSION}"
@@ -141,6 +158,24 @@ jobs:
             echo "Successfully started application << pipeline.parameters.app_name >>"
 
           name: Deploy via Domino
+      - run:
+          name: Update planned release to SUCCESS
+          command: |
+            circleci run release update << pipeline.parameters.deploy_name >> --status=SUCCESS
+          when: on_success
+      - run:
+          name: Update planned release to FAILED
+          command: |
+            circleci run release update << pipeline.parameters.deploy_name >> --status=FAILED
+          when: on_fail
+
+  cancel-deploy:
+    executor: base
+    steps:
+      - run:
+          name: Update planned release to CANCELED
+          command: |
+            circleci run release update << pipeline.parameters.deploy_name >> --status=CANCELED
 
   # Leaflet Content Front Application - Publish tag (and release) on GitHub for RC versions
   publish-github-rc:
@@ -216,6 +251,11 @@ workflows:
                 job_type: deployment
                 pipeline_id: << pipeline.id >>
                 pipeline_number: << pipeline.number >>
+
+      - cancel-deploy:
+          requires:
+            - deploy:
+                - canceled
 
       - publish-github-release:
           context:

--- a/.domino/deployment.yml
+++ b/.domino/deployment.yml
@@ -19,6 +19,8 @@ domino:
             APP_ARGS: |
               --spring.profiles.active=production
               --spring.config.location=/opt/lcfa/appconfig_lcfa.yml
+              --oauth.client-id=[dsm:domino.oauth.psproghu.prod.lcfa.client-id]
+              --oauth.client-secret=[dsm:domino.oauth.psproghu.prod.lcfa.client-secret]
           volumes:
             "[dsm:volume.logs]": "/opt/lcfa/logs:rw"
             "[dsm:volume.config.lcfa]": "/opt/lcfa/appconfig_lcfa.yml:ro"

--- a/.domino/oauth.yml
+++ b/.domino/oauth.yml
@@ -1,0 +1,19 @@
+domino:
+  oauth:
+    lcfa:
+      behavior:
+        target-provider: gateway-psproghu
+        roll-client-secret-on-deploy: true
+        use-secret-manager-for:
+          - client-secret
+          - client-id
+      tenant:
+        environment: prod
+        name: psproghu
+      client:
+        allowed-callbacks:
+          - https://psprog.hu/login/oauth2/code/leaflet
+        required-permissions:
+          - read:comments:own
+          - write:comments:own
+          - write:mail:system_startup

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ ARG APP_USER=leaflet
 ARG APP_HOME=/opt/lcfa
 ARG APP_EXECUTABLE=leaflet-lcfa-exec.jar
 ENV ENV_APP_EXECUTABLE=$APP_EXECUTABLE
+ENV JAVA_OPTS="-Xmx256M -Xlog:gc*:file=/opt/lcfa/logs/gc_lcfa.log -Djava.security.egd=file:/dev/./urandom -Duser.language=hu"
 
 RUN addgroup --system --gid 1000 $APP_USER
 RUN adduser --system --no-create-home --gid 1000 --uid 1000 $APP_USER
 RUN mkdir -p $APP_HOME
 ADD web/target/$APP_EXECUTABLE $APP_HOME
-ADD config/leaflet-lcfa-exec.conf $APP_HOME
 
 WORKDIR $APP_HOME
 RUN chmod 744 $APP_HOME
@@ -18,4 +18,4 @@ RUN chown -R $APP_USER:$APP_USER $APP_HOME
 
 USER $APP_USER
 
-ENTRYPOINT ./$ENV_APP_EXECUTABLE ${APP_ARGS}
+ENTRYPOINT exec java $JAVA_OPTS -jar $ENV_APP_EXECUTABLE ${APP_ARGS}

--- a/config/leaflet-lcfa-exec.conf
+++ b/config/leaflet-lcfa-exec.conf
@@ -1,1 +1,0 @@
-JAVA_OPTS="-Xmx256M -Xlog:gc*:file=/opt/lcfa/logs/gc_lcfa.log -Djava.security.egd=file:/dev/./urandom -Duser.language=hu"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-content-front-application</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.6.0-dev</version>
+        <version>2.7.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>leaflet-content-front-application</artifactId>
     <packaging>pom</packaging>
-    <version>2.6.0-dev</version>
+    <version>2.7.0-dev</version>
 
     <modules>
         <module>web</module>
@@ -16,7 +16,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>5.0-r2505.1</version>
+        <version>6.0-r2604.3</version>
     </parent>
 
     <properties>
@@ -104,11 +104,30 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                    <proc>full</proc>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <!--suppress UnresolvedMavenProperty -->
-                    <argLine>${argLine.surefire}</argLine>
+                    <argLine>${argLine.surefire} -javaagent:"${org.mockito:mockito-core:jar}"</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-content-front-application</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.6.0-dev</version>
+        <version>2.7.0-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,20 +29,16 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-web</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-config</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-oauth2-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-oauth2-jose</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
         <dependency>
             <groupId>hu.psprog.leaflet</groupId>
@@ -57,12 +53,12 @@
             <artifactId>oauth-frontend-support</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.thymeleaf</groupId>
-            <artifactId>thymeleaf</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jackson</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.thymeleaf</groupId>
-            <artifactId>thymeleaf-spring6</artifactId>
+            <groupId>tools.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
         </dependency>
         <dependency>
             <groupId>nz.net.ultraq.thymeleaf</groupId>
@@ -81,10 +77,6 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-xml</artifactId>
-        </dependency>
     </dependencies>
 
     <build>
@@ -98,7 +90,6 @@
                         <argument>--spring.profiles.active=${spring.profiles.active}</argument>
                         <argument>--spring.config.location=${spring.config.location}</argument>
                     </arguments>
-                    <executable>true</executable>
                 </configuration>
                 <executions>
                     <execution>

--- a/web/src/main/java/hu/psprog/leaflet/lcfa/web/config/ApplicationContextConfig.java
+++ b/web/src/main/java/hu/psprog/leaflet/lcfa/web/config/ApplicationContextConfig.java
@@ -2,7 +2,7 @@ package hu.psprog.leaflet.lcfa.web.config;
 
 import hu.psprog.leaflet.bridge.client.request.RequestAuthentication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.web.servlet.filter.OrderedRequestContextFilter;
+import org.springframework.boot.servlet.filter.OrderedRequestContextFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;

--- a/web/src/main/java/hu/psprog/leaflet/lcfa/web/config/EmbeddedWebServerAJPCustomization.java
+++ b/web/src/main/java/hu/psprog/leaflet/lcfa/web/config/EmbeddedWebServerAJPCustomization.java
@@ -4,14 +4,16 @@ import org.apache.coyote.ProtocolHandler;
 import org.apache.coyote.ajp.AbstractAjpProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 
 /**
  * Embedded Tomcat server customization.
  *
  * @author Peter Smith
+ * @deprecated Will be removed in upcoming major version
  */
+@Deprecated
 public class EmbeddedWebServerAJPCustomization implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedWebServerAJPCustomization.class);

--- a/web/src/main/java/hu/psprog/leaflet/lcfa/web/config/SecurityConfiguration.java
+++ b/web/src/main/java/hu/psprog/leaflet/lcfa/web/config/SecurityConfiguration.java
@@ -23,7 +23,7 @@ public class SecurityConfiguration {
     private static final String PATH_LOGIN_FAILURE = "/signin?auth=failure";
     private static final String PATH_PROFILE = "/profile/**";
     private static final String PATH_LOGOUT_REDIRECT = "/?auth=signout";
-    private static final String PROFILE_READ_AUTHORITY = "SCOPE_read:users:own";
+    private static final String PROFILE_READ_AUTHORITY = "SCOPE_read:access:profile";
 
     private final WebAppResources webAppResources;
     private final String logoutEndpoint;
@@ -43,7 +43,7 @@ public class SecurityConfiguration {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) {
 
         return http
                 .authorizeHttpRequests(registry -> registry

--- a/web/src/main/java/hu/psprog/leaflet/lcfa/web/config/WebMVCConfiguration.java
+++ b/web/src/main/java/hu/psprog/leaflet/lcfa/web/config/WebMVCConfiguration.java
@@ -1,12 +1,10 @@
 package hu.psprog.leaflet.lcfa.web.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import hu.psprog.leaflet.lcfa.core.utility.ResourcePathResolver;
 import hu.psprog.leaflet.lcfa.web.interceptor.CommonPageDataInterceptor;
 import hu.psprog.leaflet.lcfa.web.interceptor.ModelAndViewDebuggerInterceptor;
 import hu.psprog.leaflet.lcfa.web.thymeleaf.support.markdown.ExtendedLayoutDialect;
+import jakarta.validation.constraints.NotNull;
 import nz.net.ultraq.thymeleaf.layoutdialect.LayoutDialect;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
@@ -14,8 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
-import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -49,20 +45,11 @@ public class WebMVCConfiguration implements WebMvcConfigurer {
     }
 
     @Override
-    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+    public void addResourceHandlers(@NotNull ResourceHandlerRegistry registry) {
         webAppResources.getResources()
                 .forEach(resource -> registry
                         .addResourceHandler(resource.getHandler())
                         .addResourceLocations(resource.getLocation()));
-    }
-
-    @Bean
-    public MappingJackson2XmlHttpMessageConverter mappingJackson2XmlHttpMessageConverter(Jackson2ObjectMapperBuilder builder) {
-
-        ObjectMapper objectMapper = builder.createXmlMapper(true).build();
-        ((XmlMapper) objectMapper).enable(ToXmlGenerator.Feature.WRITE_XML_DECLARATION);
-
-        return new MappingJackson2XmlHttpMessageConverter(objectMapper);
     }
 
     @Bean

--- a/web/src/main/resources/banner.txt
+++ b/web/src/main/resources/banner.txt
@@ -4,3 +4,5 @@
               _/        _/        _/_/_/    _/_/_/_/
              _/        _/        _/        _/    _/
             _/_/_/_/    _/_/_/  _/        _/    _/
+
+          --== Powered by Spring Boot v${spring-boot.version} ==--

--- a/web/src/test/java/hu/psprog/leaflet/lcfa/web/controller/AbstractControllerTest.java
+++ b/web/src/test/java/hu/psprog/leaflet/lcfa/web/controller/AbstractControllerTest.java
@@ -1,7 +1,5 @@
 package hu.psprog.leaflet.lcfa.web.controller;
 
-import hu.psprog.leaflet.bridge.client.domain.error.ValidationErrorMessageListResponse;
-import hu.psprog.leaflet.bridge.client.domain.error.ValidationErrorMessageResponse;
 import hu.psprog.leaflet.lcfa.core.domain.common.CommonPageDataField;
 import hu.psprog.leaflet.lcfa.core.domain.common.SEOAttributes;
 import hu.psprog.leaflet.lcfa.web.factory.ModelAndViewFactory;
@@ -12,12 +10,6 @@ import org.mockito.Mock;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.ws.rs.core.Response;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -33,29 +25,10 @@ import static org.mockito.Mockito.verify;
 public abstract class AbstractControllerTest {
 
     private static final String VIEW_NAME_FORMAT = "view/%s/%s";
-    private static final String INVALID_FIELD_NAME = "field-1";
-    private static final String INVALID_FIELD_VIOLATION = "field restriction violated";
-    private static final ValidationErrorMessageListResponse VALIDATION_ERROR_MESSAGE_LIST_RESPONSE = ValidationErrorMessageListResponse.getBuilder()
-            .withValidation(Collections.singletonList(ValidationErrorMessageResponse.getBuilder()
-                    .withField(INVALID_FIELD_NAME)
-                    .withMessage(INVALID_FIELD_VIOLATION)
-                    .build()))
-            .build();
-    private static final Map<String, String> VALIDATION_RESULTS_MAP = new HashMap<>();
     private static final String FLASH_MESSAGE = ModelField.FLASH.getFieldName();
-
-    static {
-        VALIDATION_RESULTS_MAP.put(INVALID_FIELD_NAME, INVALID_FIELD_VIOLATION);
-    }
-
-    @Mock
-    HttpServletRequest request;
 
     @Mock
     RedirectAttributes redirectAttributes;
-
-    @Mock(strictness = Mock.Strictness.LENIENT)
-    Response response;
 
     @Mock
     BindingResult bindingResult;
@@ -76,7 +49,6 @@ public abstract class AbstractControllerTest {
         given(modelAndViewWrapper.withAttribute(anyString(), nullable(Object.class))).willReturn(modelAndViewWrapper);
         given(modelAndViewWrapper.withAttribute(any(ModelField.class), nullable(Object.class))).willReturn(modelAndViewWrapper);
         given(modelAndViewWrapper.build()).willReturn(modelAndView);
-        given(response.readEntity(ValidationErrorMessageListResponse.class)).willReturn(VALIDATION_ERROR_MESSAGE_LIST_RESPONSE);
     }
 
     void verifyViewCreated(String name) {

--- a/web/src/test/java/hu/psprog/leaflet/lcfa/web/thymeleaf/support/markdown/ExtendedLayoutDialectTest.java
+++ b/web/src/test/java/hu/psprog/leaflet/lcfa/web/thymeleaf/support/markdown/ExtendedLayoutDialectTest.java
@@ -1,12 +1,8 @@
 package hu.psprog.leaflet.lcfa.web.thymeleaf.support.markdown;
 
-import hu.psprog.leaflet.lcfa.core.utility.ResourcePathResolver;
-import org.commonmark.parser.Parser;
-import org.commonmark.renderer.html.HtmlRenderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.thymeleaf.processor.IProcessor;
 
@@ -25,15 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @ExtendWith(MockitoExtension.class)
 public class ExtendedLayoutDialectTest {
 
-    @Mock
-    private Parser parser;
-
-    @Mock
-    private HtmlRenderer htmlRenderer;
-
-    @Mock
-    private ResourcePathResolver resourcePathResolver;
-
     @InjectMocks
     private ExtendedLayoutDialect extendedLayoutDialect;
 
@@ -45,7 +32,7 @@ public class ExtendedLayoutDialectTest {
 
         // then
         assertThat(result, notNullValue());
-        assertThat(result.size(), equalTo(16));
+        assertThat(result.size(), equalTo(17));
         assertThat(result.stream().anyMatch(iProcessor -> iProcessor instanceof MarkdownAttributeTagProcessor), is(true));
     }
 }


### PR DESCRIPTION
 - Eliminated deprecated calls
 - Aligned Jackson imports and configuration
 - Switched to stack base BOM v6.0-r2604.3
 - Bumped application version to 2.7.0-dev
 - POM fixes (annotation processing and Mockito warnings)
 - Added OAuth application descriptor and import step in pipeline
 - Added deploy markers to CircleCI config